### PR TITLE
fix: cast avatar to string in session user object

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -60,7 +60,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session({ session, token }) {
             if (session.user) {
                 session.user.id = token.sub!;
-                session.user.avatar = token.avatar ?? "";
+                session.user.avatar = token.avatar as string;
                 session.user.email = token.email ?? '';
             }
             return session;


### PR DESCRIPTION
This pull request includes a small change to the `auth.ts` file. The change updates the type assertion for the `session.user.avatar` property to explicitly cast `token.avatar` as a string.