### PR TITLE
docs: update README to replace npm with pnpm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ vi .env
 ```
 Run local development server:
 ```bash
-npm run dev
+pnpm dev
 ```
 Migrate database
 ```bash
-npm run db:migrate
+pnpm run db:migrate
 ```
 ```bash
-npm run db:studio
+pnpm run db:studio
 ```
 Database seeding
 ```bash
-npm run db:seed
+pnpm run db:seed
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. And see [Documentation](https://github.com/ekovegeance/Fullstack-Nextjs-Templates/blob/main/DOCS.md)


### PR DESCRIPTION
This pull request updates the `README.md` file to replace `npm` commands with `pnpm` equivalents for consistency with the project's package manager.

Command updates in `README.md`:

* Replaced `npm run dev` with `pnpm dev` for starting the local development server.
* Replaced `npm run db:migrate` with `pnpm run db:migrate` for database migration.
* Replaced `npm run db:studio` with `pnpm run db:studio` for opening the database studio.
* Replaced `npm run db:seed` with `pnpm run db:seed` for database seeding.